### PR TITLE
Use trim_mode for if statement

### DIFF
--- a/templates/node/logshifter.conf.erb
+++ b/templates/node/logshifter.conf.erb
@@ -1,10 +1,10 @@
 queuesize = 1000
 inputbuffersize = 4096
-<% if scope.lookupvar('::openshift_origin::syslog_enabled') == true %>
+<% if scope.lookupvar('::openshift_origin::syslog_enabled') == true -%>
 outputtype = multi
-<% else %>
+<% else -%>
 outputtype = file
-<% end %>
+<% end -%>
 syslogbuffersize = 4096
 filebuffersize = 4096
 outputtypefromenviron = false


### PR DESCRIPTION
Because of spaces, nodes do not parse the file and do not log in the directory "filewriterdir"